### PR TITLE
Add CORS Support

### DIFF
--- a/api.py
+++ b/api.py
@@ -2,8 +2,10 @@ from flask import Flask, request, json, jsonify
 import requests
 import base64
 import spotify_service
+from flask_cors import CORS
 
 api = Flask(__name__)
+CORS(api)
 
 @api.route('/', methods = ['GET'])
 def home():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
 Flask==1.1.1
+Flask-Cors==3.0.8
 gunicorn==19.9.0
 idna==2.8
 importlib-metadata==0.18


### PR DESCRIPTION
Ajax requests from the `/dashboard` path in the Rails app are running into CORS issues. `flask-cors` is a package that allows for CORS requests, and returns the needed headers in the response. 
Currently, we'll just allow all origins, but eventually may clean it up to ensure safety and stability.